### PR TITLE
Add FTP wrapper with FTP/SFTP implementations

### DIFF
--- a/sftp-client/README.md
+++ b/sftp-client/README.md
@@ -42,3 +42,11 @@ mvn spring-boot:run
 ```
 
 The app will attempt a connection on startup and log success or failure.
+
+## API
+
+Trigger a connectivity test over HTTP:
+
+```bash
+curl -X POST http://localhost:8080/api/transfer/test
+```

--- a/sftp-client/README.md
+++ b/sftp-client/README.md
@@ -1,0 +1,44 @@
+# SFTP Client Connectivity Tester
+
+This Spring Boot app tests connectivity to an SFTP server using JSch.
+
+## Configure
+
+Update `src/main/resources/application.yml` or provide environment variables:
+
+```yaml
+sftp:
+  host: sftp.example.com
+  port: 22
+  username: my-user
+  password: my-password
+  private-key-path: /path/to/id_rsa
+  private-key-passphrase: ""
+  timeout-ms: 10000
+  strict-host-key-checking: "no"
+  protocol: "sftp"
+```
+
+Environment variable equivalents use Spring Boot relaxed binding, for example:
+
+```
+SFTP_HOST=sftp.example.com
+SFTP_PORT=22
+SFTP_USERNAME=my-user
+SFTP_PASSWORD=my-password
+SFTP_PRIVATE_KEY_PATH=/path/to/id_rsa
+SFTP_PRIVATE_KEY_PASSPHRASE=
+SFTP_TIMEOUT_MS=10000
+SFTP_STRICT_HOST_KEY_CHECKING=no
+SFTP_PROTOCOL=sftp
+```
+
+To test FTP instead of SFTP, set `sftp.protocol=ftp` and use the FTP port (typically 21).
+
+## Run
+
+```bash
+mvn spring-boot:run
+```
+
+The app will attempt a connection on startup and log success or failure.

--- a/sftp-client/README.md
+++ b/sftp-client/README.md
@@ -15,6 +15,9 @@ sftp:
   private-key-path: /path/to/id_rsa
   private-key-passphrase: ""
   timeout-ms: 10000
+  session-timeout-ms: 10000
+  server-alive-interval-ms: 10000
+  server-alive-count-max: 1
   strict-host-key-checking: "no"
   protocol: "sftp"
 ```
@@ -29,6 +32,9 @@ SFTP_PASSWORD=my-password
 SFTP_PRIVATE_KEY_PATH=/path/to/id_rsa
 SFTP_PRIVATE_KEY_PASSPHRASE=
 SFTP_TIMEOUT_MS=10000
+SFTP_SESSION_TIMEOUT_MS=10000
+SFTP_SERVER_ALIVE_INTERVAL_MS=10000
+SFTP_SERVER_ALIVE_COUNT_MAX=1
 SFTP_STRICT_HOST_KEY_CHECKING=no
 SFTP_PROTOCOL=sftp
 ```
@@ -50,3 +56,6 @@ Trigger a connectivity test over HTTP:
 ```bash
 curl -X POST http://localhost:8080/api/transfer/test
 ```
+
+If you see `read timed out`, increase `sftp.timeout-ms` or `sftp.session-timeout-ms` and
+verify the server is reachable through firewalls or VPNs.

--- a/sftp-client/pom.xml
+++ b/sftp-client/pom.xml
@@ -25,6 +25,10 @@
       <artifactId>spring-boot-starter</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.jcraft</groupId>
       <artifactId>jsch</artifactId>
       <version>0.1.55</version>

--- a/sftp-client/pom.xml
+++ b/sftp-client/pom.xml
@@ -1,0 +1,47 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>3.2.5</version>
+    <relativePath />
+  </parent>
+
+  <groupId>com.example</groupId>
+  <artifactId>sftp-client</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <name>sftp-client</name>
+  <description>Spring Boot SFTP connectivity tester</description>
+
+  <properties>
+    <java.version>17</java.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.jcraft</groupId>
+      <artifactId>jsch</artifactId>
+      <version>0.1.55</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-net</groupId>
+      <artifactId>commons-net</artifactId>
+      <version>3.10.0</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/sftp-client/src/main/java/com/example/sftpclient/ConnectionTestController.java
+++ b/sftp-client/src/main/java/com/example/sftpclient/ConnectionTestController.java
@@ -1,0 +1,24 @@
+package com.example.sftpclient;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/transfer")
+public class ConnectionTestController {
+  private final ConnectionTestService testService;
+
+  public ConnectionTestController(ConnectionTestService testService) {
+    this.testService = testService;
+  }
+
+  @PostMapping("/test")
+  public ResponseEntity<ConnectionTestResult> testConnection() {
+    ConnectionTestResult result = testService.testConnection();
+    HttpStatus status = result.isSuccess() ? HttpStatus.OK : HttpStatus.SERVICE_UNAVAILABLE;
+    return ResponseEntity.status(status).body(result);
+  }
+}

--- a/sftp-client/src/main/java/com/example/sftpclient/ConnectionTestResult.java
+++ b/sftp-client/src/main/java/com/example/sftpclient/ConnectionTestResult.java
@@ -1,0 +1,25 @@
+package com.example.sftpclient;
+
+public class ConnectionTestResult {
+  private final boolean success;
+  private final SftpProperties.Protocol protocol;
+  private final String message;
+
+  public ConnectionTestResult(boolean success, SftpProperties.Protocol protocol, String message) {
+    this.success = success;
+    this.protocol = protocol;
+    this.message = message;
+  }
+
+  public boolean isSuccess() {
+    return success;
+  }
+
+  public SftpProperties.Protocol getProtocol() {
+    return protocol;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+}

--- a/sftp-client/src/main/java/com/example/sftpclient/ConnectionTestService.java
+++ b/sftp-client/src/main/java/com/example/sftpclient/ConnectionTestService.java
@@ -12,11 +12,6 @@ public class ConnectionTestService {
 
   public ConnectionTestResult testConnection() {
     FileTransferClient client = new FtpWrapper(properties).createClient();
-    boolean success = client.testConnection();
-    String message =
-        success
-            ? "Connectivity test succeeded."
-            : "Connectivity test failed. Check logs for details.";
-    return new ConnectionTestResult(success, properties.getProtocol(), message);
+    return client.testConnection();
   }
 }

--- a/sftp-client/src/main/java/com/example/sftpclient/ConnectionTestService.java
+++ b/sftp-client/src/main/java/com/example/sftpclient/ConnectionTestService.java
@@ -1,0 +1,22 @@
+package com.example.sftpclient;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class ConnectionTestService {
+  private final SftpProperties properties;
+
+  public ConnectionTestService(SftpProperties properties) {
+    this.properties = properties;
+  }
+
+  public ConnectionTestResult testConnection() {
+    FileTransferClient client = new FtpWrapper(properties).createClient();
+    boolean success = client.testConnection();
+    String message =
+        success
+            ? "Connectivity test succeeded."
+            : "Connectivity test failed. Check logs for details.";
+    return new ConnectionTestResult(success, properties.getProtocol(), message);
+  }
+}

--- a/sftp-client/src/main/java/com/example/sftpclient/FileTransferClient.java
+++ b/sftp-client/src/main/java/com/example/sftpclient/FileTransferClient.java
@@ -1,5 +1,5 @@
 package com.example.sftpclient;
 
 public interface FileTransferClient {
-  boolean testConnection();
+  ConnectionTestResult testConnection();
 }

--- a/sftp-client/src/main/java/com/example/sftpclient/FileTransferClient.java
+++ b/sftp-client/src/main/java/com/example/sftpclient/FileTransferClient.java
@@ -1,0 +1,5 @@
+package com.example.sftpclient;
+
+public interface FileTransferClient {
+  boolean testConnection();
+}

--- a/sftp-client/src/main/java/com/example/sftpclient/FtpClient.java
+++ b/sftp-client/src/main/java/com/example/sftpclient/FtpClient.java
@@ -15,7 +15,7 @@ public class FtpClient implements FileTransferClient {
   }
 
   @Override
-  public boolean testConnection() {
+  public ConnectionTestResult testConnection() {
     FTPClient ftpClient = new FTPClient();
     try {
       ftpClient.setConnectTimeout(properties.getTimeoutMs());
@@ -23,13 +23,15 @@ public class FtpClient implements FileTransferClient {
       boolean loggedIn = ftpClient.login(properties.getUsername(), properties.getPassword());
       if (!loggedIn) {
         LOGGER.error("FTP login failed for user {}", properties.getUsername());
-        return false;
+        return new ConnectionTestResult(
+            false, properties.getProtocol(), "FTP login failed. Check credentials.");
       }
       LOGGER.info("FTP connectivity test succeeded. Connected: {}", ftpClient.isConnected());
-      return true;
+      return new ConnectionTestResult(true, properties.getProtocol(), "Connectivity test succeeded.");
     } catch (IOException ex) {
       LOGGER.error("FTP connectivity test failed: {}", ex.getMessage(), ex);
-      return false;
+      return new ConnectionTestResult(
+          false, properties.getProtocol(), "FTP connectivity test failed: " + ex.getMessage());
     } finally {
       if (ftpClient.isConnected()) {
         try {

--- a/sftp-client/src/main/java/com/example/sftpclient/FtpClient.java
+++ b/sftp-client/src/main/java/com/example/sftpclient/FtpClient.java
@@ -1,0 +1,45 @@
+package com.example.sftpclient;
+
+import java.io.IOException;
+import org.apache.commons.net.ftp.FTPClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class FtpClient implements FileTransferClient {
+  private static final Logger LOGGER = LoggerFactory.getLogger(FtpClient.class);
+
+  private final SftpProperties properties;
+
+  public FtpClient(SftpProperties properties) {
+    this.properties = properties;
+  }
+
+  @Override
+  public boolean testConnection() {
+    FTPClient ftpClient = new FTPClient();
+    try {
+      ftpClient.setConnectTimeout(properties.getTimeoutMs());
+      ftpClient.connect(properties.getHost(), properties.getPort());
+      boolean loggedIn = ftpClient.login(properties.getUsername(), properties.getPassword());
+      if (!loggedIn) {
+        LOGGER.error("FTP login failed for user {}", properties.getUsername());
+        return false;
+      }
+      LOGGER.info("FTP connectivity test succeeded. Connected: {}", ftpClient.isConnected());
+      return true;
+    } catch (IOException ex) {
+      LOGGER.error("FTP connectivity test failed: {}", ex.getMessage(), ex);
+      return false;
+    } finally {
+      if (ftpClient.isConnected()) {
+        try {
+          ftpClient.logout();
+          ftpClient.disconnect();
+          LOGGER.info("FTP session disconnected.");
+        } catch (IOException ex) {
+          LOGGER.warn("Failed to close FTP session: {}", ex.getMessage(), ex);
+        }
+      }
+    }
+  }
+}

--- a/sftp-client/src/main/java/com/example/sftpclient/FtpWrapper.java
+++ b/sftp-client/src/main/java/com/example/sftpclient/FtpWrapper.java
@@ -1,0 +1,16 @@
+package com.example.sftpclient;
+
+public class FtpWrapper {
+  private final SftpProperties properties;
+
+  public FtpWrapper(SftpProperties properties) {
+    this.properties = properties;
+  }
+
+  public FileTransferClient createClient() {
+    if (properties.getProtocol() == SftpProperties.Protocol.FTP) {
+      return new FtpClient(properties);
+    }
+    return new SftpClient(properties);
+  }
+}

--- a/sftp-client/src/main/java/com/example/sftpclient/JschLogger.java
+++ b/sftp-client/src/main/java/com/example/sftpclient/JschLogger.java
@@ -1,0 +1,30 @@
+package com.example.sftpclient;
+
+import com.jcraft.jsch.Logger;
+import org.slf4j.LoggerFactory;
+
+public class JschLogger implements Logger {
+  private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(JschLogger.class);
+
+  @Override
+  public boolean isEnabled(int level) {
+    return switch (level) {
+      case DEBUG -> LOGGER.isDebugEnabled();
+      case INFO -> LOGGER.isInfoEnabled();
+      case WARN -> LOGGER.isWarnEnabled();
+      case ERROR, FATAL -> LOGGER.isErrorEnabled();
+      default -> false;
+    };
+  }
+
+  @Override
+  public void log(int level, String message) {
+    switch (level) {
+      case DEBUG -> LOGGER.debug(message);
+      case INFO -> LOGGER.info(message);
+      case WARN -> LOGGER.warn(message);
+      case ERROR, FATAL -> LOGGER.error(message);
+      default -> LOGGER.trace(message);
+    }
+  }
+}

--- a/sftp-client/src/main/java/com/example/sftpclient/SftpClient.java
+++ b/sftp-client/src/main/java/com/example/sftpclient/SftpClient.java
@@ -3,6 +3,7 @@ package com.example.sftpclient;
 import com.jcraft.jsch.JSch;
 import com.jcraft.jsch.JSchException;
 import com.jcraft.jsch.Session;
+import java.net.SocketTimeoutException;
 import java.util.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -17,7 +18,7 @@ public class SftpClient implements FileTransferClient {
   }
 
   @Override
-  public boolean testConnection() {
+  public ConnectionTestResult testConnection() {
     JSch jsch = new JSch();
     Session session = null;
     try {
@@ -28,13 +29,17 @@ public class SftpClient implements FileTransferClient {
         session.setPassword(properties.getPassword());
       }
       session.setConfig("StrictHostKeyChecking", properties.getStrictHostKeyChecking());
+      session.setTimeout(properties.getSessionTimeoutMs());
+      session.setServerAliveInterval(properties.getServerAliveIntervalMs());
+      session.setServerAliveCountMax(properties.getServerAliveCountMax());
       session.connect(properties.getTimeoutMs());
 
       LOGGER.info("SFTP connectivity test succeeded. Session connected: {}", session.isConnected());
-      return true;
+      return new ConnectionTestResult(true, properties.getProtocol(), "Connectivity test succeeded.");
     } catch (JSchException ex) {
       LOGGER.error("SFTP connectivity test failed: {}", ex.getMessage(), ex);
-      return false;
+      return new ConnectionTestResult(
+          false, properties.getProtocol(), buildErrorMessage(ex));
     } finally {
       if (session != null && session.isConnected()) {
         session.disconnect();
@@ -54,5 +59,22 @@ public class SftpClient implements FileTransferClient {
     }
 
     jsch.addIdentity(properties.getPrivateKeyPath(), properties.getPrivateKeyPassphrase());
+  }
+
+  private String buildErrorMessage(JSchException ex) {
+    if (isTimeout(ex)) {
+      return "SFTP connectivity test failed: read timed out. "
+          + "Increase sftp.timeout-ms or sftp.session-timeout-ms, "
+          + "and verify network/firewall access.";
+    }
+    return "SFTP connectivity test failed: " + ex.getMessage();
+  }
+
+  private boolean isTimeout(JSchException ex) {
+    if (ex.getCause() instanceof SocketTimeoutException) {
+      return true;
+    }
+    String message = ex.getMessage();
+    return message != null && message.contains("Read timed out");
   }
 }

--- a/sftp-client/src/main/java/com/example/sftpclient/SftpClient.java
+++ b/sftp-client/src/main/java/com/example/sftpclient/SftpClient.java
@@ -1,0 +1,58 @@
+package com.example.sftpclient;
+
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.JSchException;
+import com.jcraft.jsch.Session;
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SftpClient implements FileTransferClient {
+  private static final Logger LOGGER = LoggerFactory.getLogger(SftpClient.class);
+
+  private final SftpProperties properties;
+
+  public SftpClient(SftpProperties properties) {
+    this.properties = properties;
+  }
+
+  @Override
+  public boolean testConnection() {
+    JSch jsch = new JSch();
+    Session session = null;
+    try {
+      configureIdentity(jsch);
+
+      session = jsch.getSession(properties.getUsername(), properties.getHost(), properties.getPort());
+      if (properties.getPassword() != null && !properties.getPassword().isBlank()) {
+        session.setPassword(properties.getPassword());
+      }
+      session.setConfig("StrictHostKeyChecking", properties.getStrictHostKeyChecking());
+      session.connect(properties.getTimeoutMs());
+
+      LOGGER.info("SFTP connectivity test succeeded. Session connected: {}", session.isConnected());
+      return true;
+    } catch (JSchException ex) {
+      LOGGER.error("SFTP connectivity test failed: {}", ex.getMessage(), ex);
+      return false;
+    } finally {
+      if (session != null && session.isConnected()) {
+        session.disconnect();
+        LOGGER.info("SFTP session disconnected.");
+      }
+    }
+  }
+
+  private void configureIdentity(JSch jsch) throws JSchException {
+    if (properties.getPrivateKeyPath() == null || properties.getPrivateKeyPath().isBlank()) {
+      return;
+    }
+
+    if (Objects.requireNonNullElse(properties.getPrivateKeyPassphrase(), "").isBlank()) {
+      jsch.addIdentity(properties.getPrivateKeyPath());
+      return;
+    }
+
+    jsch.addIdentity(properties.getPrivateKeyPath(), properties.getPrivateKeyPassphrase());
+  }
+}

--- a/sftp-client/src/main/java/com/example/sftpclient/SftpClientApplication.java
+++ b/sftp-client/src/main/java/com/example/sftpclient/SftpClientApplication.java
@@ -1,0 +1,14 @@
+package com.example.sftpclient;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+
+@SpringBootApplication
+@EnableConfigurationProperties(SftpProperties.class)
+public class SftpClientApplication {
+
+  public static void main(String[] args) {
+    SpringApplication.run(SftpClientApplication.class, args);
+  }
+}

--- a/sftp-client/src/main/java/com/example/sftpclient/SftpClientApplication.java
+++ b/sftp-client/src/main/java/com/example/sftpclient/SftpClientApplication.java
@@ -1,5 +1,6 @@
 package com.example.sftpclient;
 
+import com.jcraft.jsch.JSch;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -9,6 +10,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 public class SftpClientApplication {
 
   public static void main(String[] args) {
+    JSch.setLogger(new JschLogger());
     SpringApplication.run(SftpClientApplication.class, args);
   }
 }

--- a/sftp-client/src/main/java/com/example/sftpclient/SftpConnectivityRunner.java
+++ b/sftp-client/src/main/java/com/example/sftpclient/SftpConnectivityRunner.java
@@ -10,9 +10,11 @@ public class SftpConnectivityRunner implements CommandLineRunner {
   private static final Logger LOGGER = LoggerFactory.getLogger(SftpConnectivityRunner.class);
 
   private final SftpProperties properties;
+  private final ConnectionTestService testService;
 
-  public SftpConnectivityRunner(SftpProperties properties) {
+  public SftpConnectivityRunner(SftpProperties properties, ConnectionTestService testService) {
     this.properties = properties;
+    this.testService = testService;
   }
 
   @Override
@@ -23,9 +25,8 @@ public class SftpConnectivityRunner implements CommandLineRunner {
         properties.getHost(),
         properties.getPort());
 
-    FileTransferClient client = new FtpWrapper(properties).createClient();
-    boolean success = client.testConnection();
-    if (!success) {
+    ConnectionTestResult result = testService.testConnection();
+    if (!result.isSuccess()) {
       LOGGER.warn("Connectivity test failed using protocol {}", properties.getProtocol());
     }
   }

--- a/sftp-client/src/main/java/com/example/sftpclient/SftpConnectivityRunner.java
+++ b/sftp-client/src/main/java/com/example/sftpclient/SftpConnectivityRunner.java
@@ -1,0 +1,32 @@
+package com.example.sftpclient;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SftpConnectivityRunner implements CommandLineRunner {
+  private static final Logger LOGGER = LoggerFactory.getLogger(SftpConnectivityRunner.class);
+
+  private final SftpProperties properties;
+
+  public SftpConnectivityRunner(SftpProperties properties) {
+    this.properties = properties;
+  }
+
+  @Override
+  public void run(String... args) {
+    LOGGER.info(
+        "Attempting {} connection to {}:{}",
+        properties.getProtocol(),
+        properties.getHost(),
+        properties.getPort());
+
+    FileTransferClient client = new FtpWrapper(properties).createClient();
+    boolean success = client.testConnection();
+    if (!success) {
+      LOGGER.warn("Connectivity test failed using protocol {}", properties.getProtocol());
+    }
+  }
+}

--- a/sftp-client/src/main/java/com/example/sftpclient/SftpProperties.java
+++ b/sftp-client/src/main/java/com/example/sftpclient/SftpProperties.java
@@ -1,0 +1,93 @@
+package com.example.sftpclient;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "sftp")
+public class SftpProperties {
+  private String host;
+  private int port = 22;
+  private String username;
+  private String password;
+  private String privateKeyPath;
+  private String privateKeyPassphrase;
+  private int timeoutMs = 10000;
+  private String strictHostKeyChecking = "no";
+  private Protocol protocol = Protocol.SFTP;
+
+  public String getHost() {
+    return host;
+  }
+
+  public void setHost(String host) {
+    this.host = host;
+  }
+
+  public int getPort() {
+    return port;
+  }
+
+  public void setPort(int port) {
+    this.port = port;
+  }
+
+  public String getUsername() {
+    return username;
+  }
+
+  public void setUsername(String username) {
+    this.username = username;
+  }
+
+  public String getPassword() {
+    return password;
+  }
+
+  public void setPassword(String password) {
+    this.password = password;
+  }
+
+  public String getPrivateKeyPath() {
+    return privateKeyPath;
+  }
+
+  public void setPrivateKeyPath(String privateKeyPath) {
+    this.privateKeyPath = privateKeyPath;
+  }
+
+  public String getPrivateKeyPassphrase() {
+    return privateKeyPassphrase;
+  }
+
+  public void setPrivateKeyPassphrase(String privateKeyPassphrase) {
+    this.privateKeyPassphrase = privateKeyPassphrase;
+  }
+
+  public int getTimeoutMs() {
+    return timeoutMs;
+  }
+
+  public void setTimeoutMs(int timeoutMs) {
+    this.timeoutMs = timeoutMs;
+  }
+
+  public String getStrictHostKeyChecking() {
+    return strictHostKeyChecking;
+  }
+
+  public void setStrictHostKeyChecking(String strictHostKeyChecking) {
+    this.strictHostKeyChecking = strictHostKeyChecking;
+  }
+
+  public Protocol getProtocol() {
+    return protocol;
+  }
+
+  public void setProtocol(Protocol protocol) {
+    this.protocol = protocol;
+  }
+
+  public enum Protocol {
+    FTP,
+    SFTP
+  }
+}

--- a/sftp-client/src/main/java/com/example/sftpclient/SftpProperties.java
+++ b/sftp-client/src/main/java/com/example/sftpclient/SftpProperties.java
@@ -11,6 +11,9 @@ public class SftpProperties {
   private String privateKeyPath;
   private String privateKeyPassphrase;
   private int timeoutMs = 10000;
+  private int sessionTimeoutMs = 10000;
+  private int serverAliveIntervalMs = 10000;
+  private int serverAliveCountMax = 1;
   private String strictHostKeyChecking = "no";
   private Protocol protocol = Protocol.SFTP;
 
@@ -68,6 +71,30 @@ public class SftpProperties {
 
   public void setTimeoutMs(int timeoutMs) {
     this.timeoutMs = timeoutMs;
+  }
+
+  public int getSessionTimeoutMs() {
+    return sessionTimeoutMs;
+  }
+
+  public void setSessionTimeoutMs(int sessionTimeoutMs) {
+    this.sessionTimeoutMs = sessionTimeoutMs;
+  }
+
+  public int getServerAliveIntervalMs() {
+    return serverAliveIntervalMs;
+  }
+
+  public void setServerAliveIntervalMs(int serverAliveIntervalMs) {
+    this.serverAliveIntervalMs = serverAliveIntervalMs;
+  }
+
+  public int getServerAliveCountMax() {
+    return serverAliveCountMax;
+  }
+
+  public void setServerAliveCountMax(int serverAliveCountMax) {
+    this.serverAliveCountMax = serverAliveCountMax;
   }
 
   public String getStrictHostKeyChecking() {

--- a/sftp-client/src/main/resources/application.yml
+++ b/sftp-client/src/main/resources/application.yml
@@ -8,7 +8,3 @@ sftp:
   timeout-ms: 10000
   strict-host-key-checking: "no"
   protocol: "sftp"
-
-spring:
-  main:
-    web-application-type: none

--- a/sftp-client/src/main/resources/application.yml
+++ b/sftp-client/src/main/resources/application.yml
@@ -1,0 +1,14 @@
+sftp:
+  host: localhost
+  port: 22
+  username: your-username
+  password: your-password
+  private-key-path: ""
+  private-key-passphrase: ""
+  timeout-ms: 10000
+  strict-host-key-checking: "no"
+  protocol: "sftp"
+
+spring:
+  main:
+    web-application-type: none

--- a/sftp-client/src/main/resources/application.yml
+++ b/sftp-client/src/main/resources/application.yml
@@ -6,5 +6,8 @@ sftp:
   private-key-path: ""
   private-key-passphrase: ""
   timeout-ms: 10000
+  session-timeout-ms: 10000
+  server-alive-interval-ms: 10000
+  server-alive-count-max: 1
   strict-host-key-checking: "no"
   protocol: "sftp"


### PR DESCRIPTION
### Motivation
- Provide a protocol-agnostic connectivity tester so the tool can validate both FTP and SFTP servers from the same codebase.
- Introduce an abstraction to make it easy to add other file-transfer protocols or implementations in the future.

### Description
- Add a `FileTransferClient` interface and concrete implementations `SftpClient` (JSch) and `FtpClient` (Apache Commons Net) to encapsulate protocol-specific connection logic.
- Add `FtpWrapper` factory that selects the appropriate implementation based on a new `protocol` setting on `SftpProperties` and update `SftpConnectivityRunner` to delegate to this factory.
- Extend `SftpProperties` with a `Protocol` enum (default `SFTP`) and add `protocol` to `application.yml` and `README.md` documentation.
- Add the `commons-net` dependency to `pom.xml` to support the FTP client implementation.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69791f1d5a3483339aafec5747a8a343)